### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/02 PyQt Widgets/main.py
+++ b/src/02 PyQt Widgets/main.py
@@ -116,7 +116,7 @@ class WidgetGallery(QDialog):
     def advanceProgressBar(self):
         curVal = self.progressBar.value()
         maxVal = self.progressBar.maximum()
-        self.progressBar.setValue(curVal + (maxVal - curVal) / 100)
+        self.progressBar.setValue(curVal + (maxVal - curVal) // 100)
 
     def createTopLeftGroupBox(self):
         self.topLeftGroupBox = QGroupBox("Group 1")


### PR DESCRIPTION
Integer division using `/` is deprecated. Use `//` instead.

> ...pyqt\examples\src\02 PyQt Widgets\main.py:119: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
>   self.progressBar.setValue(curVal + (maxVal - curVal) / 100)