### PR TITLE
Fixed the `NameError`

### DIFF
--- a/src/07 Qt Text Editor/main.py
+++ b/src/07 Qt Text Editor/main.py
@@ -16,7 +16,7 @@ class MainWindow(QMainWindow):
             	# This happens when the user closes the Save As... dialog.
             	# We do not want to close the window in this case because it
             	# would throw away unsaved changes.
-                event.ignore()
+                e.ignore()
         elif answer & QMessageBox.Cancel:
             e.ignore()
 


### PR DESCRIPTION
Fixed the `NameError` in `examples/src/07 Qt Text Editor/main.py` that occurs when the user clicks save, but then closes the Save As... dialog. Was fixed by changing `event.ignore()` to `e.ignore()`.